### PR TITLE
Add SocketIO support for real‑time orders

### DIFF
--- a/render.yaml.txt
+++ b/render.yaml.txt
@@ -4,5 +4,5 @@ services:
     env: python
     plan: free
     buildCommand: ""
-    startCommand: python app.py
+    startCommand: gunicorn --worker-class eventlet -w 1 app:app
     autoDeploy: true

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ Flask==3.1.0
 flask-cors==4.0.0
 requests==2.31.0
 gunicorn==21.2.0
+Flask-SocketIO==5.3.6
+eventlet==0.33.3


### PR DESCRIPTION
## Summary
- integrate Flask-SocketIO and create a SocketIO instance
- add `/submit_order` endpoint that broadcasts new orders
- use SocketIO's `run` method when developing locally
- update dependencies to include Flask-SocketIO and eventlet
- adjust Render start command to use an eventlet worker

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_68457dbdca588333b86f5c7f0ba201ce