### PR TITLE
Fix POS total formatting

### DIFF
--- a/app.py
+++ b/app.py
@@ -41,6 +41,13 @@ TIKKIE_PAYMENT_LINK = "https://tikkie.me/pay/example"
 # In-memory log of orders for today's overview
 ORDERS = []
 
+def safe_float(value, default=0.0):
+    """Return value as float if possible, otherwise default."""
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
 def build_google_maps_link(data):
     """Return a Google Maps search link for the order address."""
     street = data.get("street", "").strip()
@@ -367,7 +374,9 @@ def api_send_order():
         "delivery_fee": data.get("delivery_fee") or (data.get("summary") or {}).get("delivery"),
         "tip": data.get("tip"),
         "btw": data.get("btw") or (data.get("summary") or {}).get("btw"),
-        "totaal": data.get("totaal") or (data.get("summary") or {}).get("total"),
+        "totaal": safe_float(
+            data.get("totaal") or (data.get("summary") or {}).get("total")
+        ),
         "discount_amount": (data.get("summary") or {}).get("discountAmount"),
     }
     socketio.emit("new_order", socket_order)
@@ -461,7 +470,9 @@ def submit_order():
         "delivery_fee": data.get("delivery_fee") or (data.get("summary") or {}).get("delivery"),
         "tip": data.get("tip"),
         "btw": data.get("btw") or (data.get("summary") or {}).get("btw"),
-        "totaal": data.get("totaal") or (data.get("summary") or {}).get("total"),
+        "totaal": safe_float(
+            data.get("totaal") or (data.get("summary") or {}).get("total")
+        ),
         "discount_amount": (data.get("summary") or {}).get("discountAmount"),
     }
     socketio.emit("new_order", socket_order)


### PR DESCRIPTION
## Summary
- ensure total value is always numeric when emitting orders
- add helper `safe_float` for conversions

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_6850fcabe1e483339381cb8df4320069