### PR TITLE
Fix totals missing in order overview

### DIFF
--- a/app.py
+++ b/app.py
@@ -155,6 +155,28 @@ def record_order(order_data, pos_ok):
         "pickup_time": pickup_time,
         "delivery_time": delivery_time,
         "pos_ok": pos_ok,
+        # Persist pricing fields for the POS overview
+        "subtotal": order_data.get("subtotal")
+        or (order_data.get("summary") or {}).get("subtotal"),
+        "packaging_fee": order_data.get("packaging_fee")
+        or (order_data.get("summary") or {}).get("packaging"),
+        "delivery_fee": order_data.get("delivery_fee")
+        or (order_data.get("summary") or {}).get("delivery"),
+        "tip": order_data.get("tip"),
+        "btw": order_data.get("btw")
+        or (order_data.get("summary") or {}).get("btw"),
+        # Store total under both Dutch and English field names for compatibility
+        "totaal": (
+            order_data.get("totaal")
+            or order_data.get("total")
+            or (order_data.get("summary") or {}).get("total")
+        ),
+        "total": (
+            order_data.get("totaal")
+            or order_data.get("total")
+            or (order_data.get("summary") or {}).get("total")
+        ),
+        "discount_amount": (order_data.get("summary") or {}).get("discountAmount"),
     })
 
 
@@ -288,6 +310,15 @@ def _orders_overview():
                 # Older entries may still use camelCase; support both
                 "pickup_time": entry.get("pickup_time") or entry.get("pickupTime"),
                 "delivery_time": entry.get("delivery_time") or entry.get("deliveryTime"),
+                "subtotal": entry.get("subtotal"),
+                "packaging_fee": entry.get("packaging_fee"),
+                "delivery_fee": entry.get("delivery_fee"),
+                "tip": entry.get("tip"),
+                "btw": entry.get("btw"),
+                # Return totals under both Dutch and English field names
+                "totaal": entry.get("totaal"),
+                "total": entry.get("totaal"),
+                "discount_amount": entry.get("discount_amount"),
             })
     return overview
 
@@ -367,7 +398,9 @@ def api_send_order():
         "delivery_fee": data.get("delivery_fee") or (data.get("summary") or {}).get("delivery"),
         "tip": data.get("tip"),
         "btw": data.get("btw") or (data.get("summary") or {}).get("btw"),
-        "totaal": data.get("totaal") or (data.get("summary") or {}).get("total"),
+        # Emit both 'totaal' and 'total' for frontend compatibility
+        "totaal": data.get("totaal") or data.get("total") or (data.get("summary") or {}).get("total"),
+        "total": data.get("totaal") or data.get("total") or (data.get("summary") or {}).get("total"),
         "discount_amount": (data.get("summary") or {}).get("discountAmount"),
     }
     socketio.emit("new_order", socket_order)
@@ -461,7 +494,9 @@ def submit_order():
         "delivery_fee": data.get("delivery_fee") or (data.get("summary") or {}).get("delivery"),
         "tip": data.get("tip"),
         "btw": data.get("btw") or (data.get("summary") or {}).get("btw"),
-        "totaal": data.get("totaal") or (data.get("summary") or {}).get("total"),
+        # Emit both 'totaal' and 'total' for frontend compatibility
+        "totaal": data.get("totaal") or data.get("total") or (data.get("summary") or {}).get("total"),
+        "total": data.get("totaal") or data.get("total") or (data.get("summary") or {}).get("total"),
         "discount_amount": (data.get("summary") or {}).get("discountAmount"),
     }
     socketio.emit("new_order", socket_order)


### PR DESCRIPTION
## Summary
- persist pricing totals in memory for today's orders
- include both `totaal` and `total` fields in API responses

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68519865e594833388d04b0a8121f499