### PR TITLE
Add order number to all notifications

### DIFF
--- a/app.py
+++ b/app.py
@@ -154,6 +154,7 @@ def record_order(order_data, pos_ok):
         # Use snake_case for time fields when storing orders
         "pickup_time": pickup_time,
         "delivery_time": delivery_time,
+        "order_number": order_data.get("order_number") or order_data.get("orderNumber"),
         "pos_ok": pos_ok,
         "totaal": order_data.get("totaal") or (order_data.get("summary") or {}).get("total")  # ✅ 添加这行
     })
@@ -162,6 +163,9 @@ def record_order(order_data, pos_ok):
 def format_order_notification(data):
     """Create a readable notification message from the order payload."""
     lines = []
+    order_number = data.get("order_number") or data.get("orderNumber")
+    if order_number:
+        lines.append(f"🧾 Bestelnummer: {order_number}")
     name = data.get("name")
     if name:
         lines.append(f"Naam: {name}")
@@ -287,6 +291,7 @@ def _orders_overview():
                 "totaal": entry.get("totaal"),
                 "pickup_time": entry.get("pickup_time") or entry.get("pickupTime"),
                 "delivery_time": entry.get("delivery_time") or entry.get("deliveryTime"),
+                "order_number": entry.get("order_number") or entry.get("orderNumber"),
             })
     return overview
 
@@ -352,6 +357,7 @@ def api_send_order():
         "email": data.get("email", ""),
         "payment_method": payment_method,
         "items": data.get("items", {}),
+        "order_number": data.get("order_number") or data.get("orderNumber"),
         "street": data.get("street", ""),
         "house_number": data.get("houseNumber", ""),
         "postcode": data.get("postcode", ""),
@@ -446,6 +452,7 @@ def submit_order():
         "email": data.get("email", ""),
         "payment_method": payment_method,
         "items": data.get("items", {}),
+        "order_number": data.get("order_number") or data.get("orderNumber"),
         "street": data.get("street", ""),
         "house_number": data.get("houseNumber", ""),
         "postcode": data.get("postcode", ""),


### PR DESCRIPTION
## Summary
- include `order_number` in the in-memory order log and overview
- show `order_number` at the top of formatted notifications
- emit `order_number` with socket messages for POS

## Testing
- `python -m py_compile app.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68578e0568748333b47d10ffbbe0e11f