### PR TITLE
Add site availability settings

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -1,0 +1,5 @@
+{
+  "is_open": "true",
+  "open_time": "11:00",
+  "close_time": "21:00"
+}

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -7,6 +7,10 @@
     <option value="true" {% if is_open == 'true' %}selected{% endif %}>营业</option>
     <option value="false" {% if is_open == 'false' %}selected{% endif %}>暂停接单</option>
   </select>
+  <br>
+  <label>营业时间:</label>
+  <input type="time" name="open_time" value="{{ open_time }}"> -
+  <input type="time" name="close_time" value="{{ close_time }}">
   <button type="submit">保存</button>
 </form>
 <p><a href="{{ url_for('logout') }}">Logout</a></p>

--- a/templates/index (27).html
+++ b/templates/index (27).html
@@ -4049,25 +4049,44 @@ sliderTrack.addEventListener('touchmove', (e) => {
 </script>
 <script src="https://cdn.socket.io/4.5.4/socket.io.min.js"></script>
 <script>
-function updateStatus(val){
+function inBusinessHours(settings){
+  if(!settings.open_time || !settings.close_time){
+    return true;
+  }
+  const now = new Date();
+  const [oh, om] = settings.open_time.split(':');
+  const [ch, cm] = settings.close_time.split(':');
+  const nowMin = now.getHours()*60 + now.getMinutes();
+  const openMin = parseInt(oh)*60 + parseInt(om);
+  const closeMin = parseInt(ch)*60 + parseInt(cm);
+  if(openMin <= closeMin){
+    return nowMin >= openMin && nowMin < closeMin;
+  }
+  return nowMin >= openMin || nowMin < closeMin;
+}
+
+function updateStatus(settings){
   const banner = document.getElementById('status-banner');
-  if(val === 'false'){
-    banner.textContent = '暂不接单';
-    banner.style.display = 'block';
-  }else{
+  const openFlag = settings.is_open !== 'false';
+  const timeOk = inBusinessHours(settings);
+  if(openFlag && timeOk){
     banner.textContent = '';
     banner.style.display = 'none';
+  }else{
+    banner.textContent = '暂不接单';
+    banner.style.display = 'block';
   }
 }
+
 function fetchStatus(){
-  fetch('/api/settings/is_open')
+  fetch('/api/settings')
     .then(r => r.json())
-    .then(d => updateStatus(d.is_open));
+    .then(updateStatus);
 }
 fetchStatus();
 setInterval(fetchStatus, 30000);
 const socket = io();
-socket.on('setting_update', d => { if(d.key === 'is_open'){ updateStatus(d.value); }});
+socket.on('setting_update', fetchStatus);
 </script>
 
 <div id="reviewsModal" style="display:none; position:fixed; inset:0; background:rgba(0,0,0,0.5); align-items:center; justify-content:center; z-index:1000;">


### PR DESCRIPTION
## Summary
- manage global opening/closing times in `settings.json`
- expose settings API endpoints
- update dashboard to edit hours and open state
- fetch and apply availability on the main site

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6862b778d0c883338ecb2b7f2a7a68b8