### PR TITLE
Implement order completion toggle

### DIFF
--- a/app.py
+++ b/app.py
@@ -284,7 +284,21 @@ def record_order(order_data, pos_ok):
         "totaal": order_data.get("totaal") or (order_data.get("summary") or {}).get("total"),  # ✅ 添加这行
         "discountAmount": order_data.get("discountAmount"),
         "discountCode": order_data.get("discountCode"),
+        "is_completed": False,
     })
+
+
+def set_order_completed(order_number: str, completed: bool) -> bool:
+    """Mark an order as completed or not in the in-memory list."""
+    for entry in ORDERS:
+        if entry.get("order_number") == order_number:
+            entry["is_completed"] = completed
+            socketio.emit(
+                "order_status",
+                {"order_number": order_number, "is_completed": completed},
+            )
+            return True
+    return False
 
 
 def format_order_notification(data):
@@ -413,6 +427,7 @@ def _orders_overview():
                 "pickup_time": entry.get("pickup_time") or entry.get("pickupTime"),
                 "delivery_time": entry.get("delivery_time") or entry.get("deliveryTime"),
                 "order_number": entry.get("order_number"),
+                "is_completed": entry.get("is_completed", False),
             })
     return overview
 
@@ -537,6 +552,7 @@ def order_complete():
     name = data.get("name", "")
     email = data.get("email", "")
     order_type = data.get("order_type", "afhaal")
+    completed = data.get("completed", True)
 
     if not order_number:
         return jsonify({"status": "fail", "error": "Ontbrekend ordernummer"}), 400
@@ -573,6 +589,7 @@ def order_complete():
         )
         send_simple_email(subject, email_body, email)
 
+    set_order_completed(order_number, completed)
     return jsonify({"status": "ok"})
 
 @app.route('/validate_discount', methods=['POST'])

--- a/templates/orders_table.html
+++ b/templates/orders_table.html
@@ -90,11 +90,12 @@ th:last-child {
        <th>Tijdslot</th>
        <th>Betaalwijze</th>
        <th>Ordernummer</th>
+       <th>Status</th>
       </tr>
     </thead>
     <tbody>
-    {% for order in orders %}
-      <tr>
+  {% for order in orders %}
+      <tr{% if order.is_completed %} class="completed"{% endif %}>
         <td>{{ order.created_at_local.strftime('%Y-%m-%d') }}</td>
         <td>{{ order.created_at_local.strftime('%H:%M') }}</td>
         {% set is_delivery = order.order_type in ['delivery', 'bezorgen'] %}
@@ -135,6 +136,11 @@ th:last-child {
         </td>
         <td>{{ order.payment_method }}</td>
         <td>{{ order.order_number or '' }}</td>
+        <td>
+          <button class="complete-btn" data-number="{{ order.order_number }}">
+            {{ 'Undone' if order.is_completed else '完成' }}
+          </button>
+        </td>
       </tr>
     {% endfor %}
     </tbody>

--- a/templates/pos.html
+++ b/templates/pos.html
@@ -467,6 +467,9 @@
   0%,100% { background-color: #eaffea; }
   50% { background-color: #fff; }
 }
+.completed {
+  background-color: #d4edda;
+}
 
 /* 桌面显示长按钮，确保隐藏圆按钮 */
 @media (min-width: 768px) {
@@ -810,6 +813,21 @@ document.addEventListener('DOMContentLoaded',()=>{
       if(e.target===cartPanel) cartPanel.classList.remove('open');
     });
   }
+  document.querySelectorAll('.complete-btn').forEach(btn=>{
+    const tr = btn.closest('tr');
+    btn.addEventListener('click',()=>{
+      const cells = tr.children;
+      const order = {
+        order_number: btn.dataset.number || cells[15]?.textContent || '',
+        customer_name: cells[3].textContent,
+        phone: cells[4].textContent,
+        email: cells[5].textContent === '-' ? '' : cells[5].textContent,
+        order_type: cells[2].textContent.trim().toLowerCase() === 'bezorgen' ? 'bezorg' : 'afhaal',
+        is_completed: tr.classList.contains('completed')
+      };
+      toggleComplete(tr, order, btn);
+    });
+  });
   updateCart();
   toggleAddress();
   updateTodayBadge();
@@ -1164,6 +1182,7 @@ function formatCurrency(value){
 
     const tr = document.createElement('tr');
     if (order.id) tr.dataset.id = order.id;
+    if(order.is_completed) tr.classList.add('completed');
     const isDelivery = ['delivery', 'bezorgen'].includes(order.order_type);
     const items = Object.entries(order.items || {}).map(([n, i]) => `<li>${n} x ${i.qty}</li>`).join('');
     let fooi = parseFloat(order.fooi ?? order.tip);
@@ -1201,7 +1220,8 @@ function formatCurrency(value){
         <td>${isDelivery ? `${order.street} ${order.house_number} ${order.postcode} ${order.city}${order.maps_link ? ` <a href="${order.maps_link}" target="_blank">📍Maps</a>` : ''}` : '-'}</td>
         <td>${isDelivery ? (delivery || '-') : (pickup || '-')}</td>
         <td>${order.payment_method || ''}</td>
-        <td>${order.order_number || '-'}</td>`;
+        <td>${order.order_number || '-'}</td>
+        <td><button class="complete-btn">${order.is_completed ? 'Undone' : '完成'}</button></td>`;
       
     tr.dataset.sortKey = getSortKey(order);
     if(highlight){
@@ -1210,6 +1230,10 @@ function formatCurrency(value){
     }
     insertSorted(tbody, tr);
     updateTodayBadge();
+    const btn = tr.querySelector('.complete-btn');
+    if(btn){
+      btn.addEventListener('click',()=>toggleComplete(tr, order, btn));
+    }
     return tr;
   }
 
@@ -1245,6 +1269,21 @@ function formatCurrency(value){
     setTimeout(() => socket.connect(), 1000);
   });
 
+  socket.on('order_status', data => {
+    const {order_number, is_completed} = data;
+    const rows = document.querySelectorAll('.orders-panel tbody tr');
+    rows.forEach(row => {
+      const numCell = row.children[15];
+      if(numCell && numCell.textContent === String(order_number)){
+        row.classList.toggle('completed', is_completed);
+        const btn = row.querySelector('.complete-btn');
+        if(btn){
+          btn.textContent = is_completed ? 'Undone' : '完成';
+        }
+      }
+    });
+  });
+
   // 轮询作为备份
   function fetchOrders() {
   fetch('/pos/orders_today?json=1')
@@ -1270,6 +1309,28 @@ function formatCurrency(value){
       clearInterval(pollTimer);
       pollTimer = null;
     }
+  }
+
+  function toggleComplete(tr, order, btn){
+    const newVal = !order.is_completed;
+    fetch('/api/order_complete', {
+      method:'POST',
+      headers:{'Content-Type':'application/json'},
+      body: JSON.stringify({
+        order_number: order.order_number,
+        name: order.customer_name,
+        phone: order.phone,
+        email: order.email,
+        order_type: order.order_type,
+        completed: newVal
+      })
+    }).then(r=>r.json()).then(res=>{
+      if(res.status==='ok'){
+        order.is_completed = newVal;
+        btn.textContent = newVal ? 'Undone' : '完成';
+        tr.classList.toggle('completed', newVal);
+      }
+    });
   }
 
   window.addEventListener('beforeunload', () => socket.disconnect());


### PR DESCRIPTION
## Summary
- add `is_completed` tracking in server
- expose helper to change completion status and emit socket event
- extend API `/api/order_complete` to toggle completion
- show completion buttons in POS interface

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6866a0e0a1dc83338eac7048279c2151