### PR TITLE
Add Mollie webhook handling

### DIFF
--- a/env.example
+++ b/env.example
@@ -17,7 +17,7 @@ ADMIN_EMAIL=qianchennl@gmail.com       # 收件人邮箱（也用于管理）
 # ==== Mollie 支付配置 ====
 MOLLIE_API_KEY=test_E6gVk3tT2Frgdedj9Bcexar82dgUMe                 # Mollie 测试 API key
 MOLLIE_REDIRECT_URL=https://novaasia.nl/payment-success            # 支付成功后跳转地址
-MOLLIE_WEBHOOK_URL=https://flask-order-api.onrender.com/mollie_webhook  # Mollie webhook 地址
+MOLLIE_WEBHOOK_URL=https://flask-order-api.onrender.com/webhook  # Mollie webhook 地址
 
 # ==== 数据库连接字符串 ====
 DATABASE_URL=postgresql://novaasia_db_user:8PpdenNvRzaMdrpbW3WyKsWFyKxTvL9I@dpg-d13t4rumcj7s738e0qtg-a.oregon-postgres.render.com:5432/novaasia_db

--- a/render.yaml
+++ b/render.yaml
@@ -30,5 +30,5 @@ services:
       - key: MOLLIE_REDIRECT_URL
         value: https://novaasia.nl/payment-success
       - key: MOLLIE_WEBHOOK_URL
-        value: https://flask-order-api.onrender.com/mollie_webhook
+        value: https://flask-order-api.onrender.com/webhook
     autoDeploy: true   # ✅ 需要顶格对齐 services 的子项

--- a/templates/pos.html
+++ b/templates/pos.html
@@ -1284,6 +1284,20 @@ function formatCurrency(value){
     });
   });
 
+  socket.on('new_paid_order', data => {
+    const {order_id} = data;
+    const rows = document.querySelectorAll('.orders-panel tbody tr');
+    rows.forEach(row => {
+      const numCell = row.children[13];
+      if(numCell && numCell.textContent === String(order_id)){
+        const payCell = row.children[12];
+        if(payCell){
+          payCell.textContent = 'Paid';
+        }
+      }
+    });
+  });
+
   // 轮询作为备份
   function fetchOrders() {
   fetch('/pos/orders_today?json=1')


### PR DESCRIPTION
## Summary
- configure webhook URL
- post payment status to `/webhook`
- send Telegram/email notifications when Mollie payment succeeds
- emit `new_paid_order` event for the POS page
- display paid status in the POS interface

## Testing
- `python3 -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6868c8b85d4c83339887c6def77347e2