### PR TITLE
Add bubble tea sold out toggle

### DIFF
--- a/app.py
+++ b/app.py
@@ -37,8 +37,15 @@ def load_settings():
     try:
         with open(SETTINGS_FILE, "r") as f:
             SETTINGS = json.load(f)
+        if "bubble_tea_available" not in SETTINGS:
+            SETTINGS["bubble_tea_available"] = "true"
     except Exception:
-        SETTINGS = {"is_open": "true", "open_time": "11:00", "close_time": "21:00"}
+        SETTINGS = {
+            "is_open": "true",
+            "open_time": "11:00",
+            "close_time": "21:00",
+            "bubble_tea_available": "true",
+        }
 
 def save_settings():
     try:
@@ -770,6 +777,7 @@ def dashboard():
         is_open=SETTINGS.get('is_open', 'true'),
         open_time=SETTINGS.get('open_time', '11:00'),
         close_time=SETTINGS.get('close_time', '21:00'),
+        bubble_tea_available=SETTINGS.get('bubble_tea_available', 'true'),
     )
 
 
@@ -779,6 +787,7 @@ def update_setting():
     is_open = request.form.get('is_open')
     open_time = request.form.get('open_time')
     close_time = request.form.get('close_time')
+    bubble_tea_available = request.form.get('bubble_tea_available')
     if is_open is not None:
         SETTINGS['is_open'] = is_open
         changed['is_open'] = is_open
@@ -788,6 +797,9 @@ def update_setting():
     if close_time:
         SETTINGS['close_time'] = close_time
         changed['close_time'] = close_time
+    if bubble_tea_available is not None:
+        SETTINGS['bubble_tea_available'] = bubble_tea_available
+        changed['bubble_tea_available'] = bubble_tea_available
     if changed:
         save_settings()
         for k, v in changed.items():

--- a/settings.json
+++ b/settings.json
@@ -2,4 +2,5 @@
   "is_open": "true",
   "open_time": "11:00",
   "close_time": "21:00"
+  ,"bubble_tea_available": "true"
 }

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -11,6 +11,12 @@
   <label>营业时间:</label>
   <input type="time" name="open_time" value="{{ open_time }}"> -
   <input type="time" name="close_time" value="{{ close_time }}">
+  <br>
+  <label>奶茶状态:</label>
+  <select name="bubble_tea_available">
+    <option value="true" {% if bubble_tea_available == 'true' %}selected{% endif %}>供应中</option>
+    <option value="false" {% if bubble_tea_available == 'false' %}selected{% endif %}>售罄</option>
+  </select>
   <button type="submit">保存</button>
 </form>
 <p><a href="{{ url_for('logout') }}">Logout</a></p>

--- a/templates/index (27).html
+++ b/templates/index (27).html
@@ -1257,6 +1257,26 @@ input:focus, select:focus, textarea:focus {
     display: block !important;
   }
 }
+
+  /* Sold out styling */
+  .menu-item.sold-out {
+    pointer-events: none;
+    opacity: 0.5;
+  }
+  .menu-item.sold-out .qty-box {
+    display: none;
+  }
+  .menu-item.sold-out::after {
+    content: '售罄';
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    background: rgba(255, 255, 255, 0.8);
+    padding: 4px 8px;
+    border-radius: 8px;
+    font-weight: bold;
+  }
 </style>
 
 
@@ -4086,6 +4106,23 @@ function updateStatus(settings){
     banner.textContent = '暂不接单';
     banner.style.display = 'block';
   }
+
+  const bubbleItem = document.querySelector('[data-name="Bubble Tea"]');
+  const bubbleQty = document.getElementById('bubbleTeaQty');
+  const bubbleMinus = document.querySelector('.qty-minus[data-target="bubbleTeaQty"]');
+  const bubblePlus = document.querySelector('.qty-plus[data-target="bubbleTeaQty"]');
+  const available = settings.bubble_tea_available !== 'false';
+  if(bubbleItem){
+    if(available){
+      bubbleItem.classList.remove('sold-out');
+    }else{
+      bubbleItem.classList.add('sold-out');
+      if(bubbleQty) bubbleQty.value = 0;
+    }
+  }
+  [bubbleQty, bubbleMinus, bubblePlus].forEach(el => {
+    if(el) el.disabled = !available;
+  });
 }
 
 function fetchStatus(){


### PR DESCRIPTION
## Summary
- add `bubble_tea_available` setting
- expose bubble tea availability on dashboard
- disable bubble tea ordering when sold out

## Testing
- `python3 -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_686bcef95cbc8333b254e74049144e35