### PR TITLE
Handle ZSM time strings

### DIFF
--- a/app.py
+++ b/app.py
@@ -3,6 +3,7 @@ from flask import Flask, request, jsonify, render_template, redirect, url_for
 from flask_cors import CORS
 from flask_socketio import SocketIO
 import requests
+import re
 import smtplib
 import string
 import secrets
@@ -100,6 +101,28 @@ def sort_items(items):
         sorted_items[name] = item
 
     return sorted_items
+
+# === Time normalization helpers ===
+def _normalize_time_value(val: str) -> str:
+    """Return time string without any embedded 'ZSM' text."""
+    if not val:
+        return ""
+    # remove the literal string 'ZSM' case-insensitively
+    cleaned = re.sub(r"(?i)ZSM", "", str(val)).strip()
+    return cleaned
+
+
+def normalize_time_fields(data: dict) -> None:
+    """Strip ZSM from common time fields in-place."""
+    for key in [
+        "tijdslot",
+        "delivery_time",
+        "deliveryTime",
+        "pickup_time",
+        "pickupTime",
+    ]:
+        if key in data and isinstance(data[key], str):
+            data[key] = _normalize_time_value(data[key])
 
 def build_google_maps_link(data):
     """Return a Google Maps search link for the order address."""
@@ -555,6 +578,7 @@ def get_orders_today():
 @app.route("/api/send", methods=["POST"])
 def api_send_order():
     data = request.get_json()
+    normalize_time_fields(data)
     message = data.get("message", "")
     remark = data.get("opmerking") or data.get("remark", "")
     data["opmerking"] = remark
@@ -650,6 +674,7 @@ def api_send_order():
 @app.route('/api/order_time_changed', methods=['POST'])
 def order_time_changed():
     data = request.get_json() or {}
+    normalize_time_fields(data)
 
     order_number = data.get("order_number", "")
     name = data.get("name", "")
@@ -892,6 +917,7 @@ def update_setting():
 @app.route("/submit_order", methods=["POST"])
 def submit_order():
     data = request.get_json()
+    normalize_time_fields(data)
     message = data.get("message", "")
     remark = data.get("opmerking") or data.get("remark", "")
     data["opmerking"] = remark


### PR DESCRIPTION
## Summary
- strip the new `ZSM` label from incoming time fields
- normalize time fields for `/api/send`, `/submit_order`, and `/api/order_time_changed`

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_687b40e90030833395abcba48aecfb65