### PR TITLE
Fix SENDER_EMAIL NameError

### DIFF
--- a/app.py
+++ b/app.py
@@ -66,6 +66,8 @@ SMTP_PORT = 587
 SMTP_USERNAME = "92a3ac002@smtp-brevo.com"
 SMTP_PASSWORD = os.environ.get("SMTP_PASSWORD")
 FROM_EMAIL = "orders@novaasia.nl"
+# Compatibility alias used by old code paths
+SENDER_EMAIL = FROM_EMAIL
 
 # === POS 配置 ===
 # Endpoint for forwarding orders to the POS system. Replace with the actual URL.


### PR DESCRIPTION
## Summary
- alias `SENDER_EMAIL` to `FROM_EMAIL` so old code paths still work

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_687e38bf32ec83338da19eba8d6b4112