### PR TITLE
feat: centralize pricing

### DIFF
--- a/app.py
+++ b/app.py
@@ -32,6 +32,7 @@ socketio = SocketIO(app, cors_allowed_origins="*")
 
 SETTINGS_FILE = "settings.json"
 SETTINGS = {}
+PRICES_FILE = "prices.json"
 
 def load_settings():
     global SETTINGS
@@ -56,6 +57,15 @@ def save_settings():
         print(f"Failed to save settings: {e}")
 
 load_settings()
+
+
+def load_prices():
+    """Load product prices from JSON file."""
+    try:
+        with open(PRICES_FILE, "r") as f:
+            return json.load(f)
+    except Exception:
+        return {}
 
 # === Telegram 配置 ===
 BOT_TOKEN = '7509433067:AAGoLc1NVWqmgKGcrRVb3DwMh1o5_v5Fyio'
@@ -644,6 +654,40 @@ def get_orders_today():
 def api_send_order():
     data = request.get_json()
 
+    prices = load_prices()
+    items = data.get("items", {})
+    sanitized_items = {}
+    subtotal = 0.0
+    packaging_fee = 0.0
+    for name, item in items.items():
+        qty = int(item.get("qty", 0))
+        info = prices.get(name, {})
+        price = float(info.get("price", 0))
+        pack = float(info.get("packaging", 0))
+        subtotal += price * qty
+        packaging_fee += pack * qty
+        sanitized_items[name] = {"price": price, "qty": qty, "packaging": pack}
+    delivery_fee = 2.5 if data.get("orderType") == "bezorgen" else 0.0
+    tip = float(data.get("tip") or 0)
+    discount = float(data.get("discountAmount") or data.get("discount_amount") or 0)
+    btw = (subtotal + packaging_fee) * 9 / 109
+    totaal = subtotal + packaging_fee + delivery_fee + tip - discount
+    data["items"] = sanitized_items
+    data["subtotal"] = round(subtotal, 2)
+    data["packaging_fee"] = round(packaging_fee, 2)
+    data["delivery_fee"] = round(delivery_fee, 2)
+    data["btw"] = round(btw, 2)
+    data["totaal"] = round(totaal, 2)
+    data["total"] = data["totaal"]
+    data["summary"] = {
+        "subtotal": f"{subtotal:.2f}",
+        "packaging": f"{packaging_fee:.2f}",
+        "delivery": f"{delivery_fee:.2f}",
+        "discount_amount": f"{discount:.2f}",
+        "btw": f"{btw:.2f}",
+        "total": f"{totaal:.2f}",
+    }
+
     # 基础字段预处理
     message = data.get("message", "")
     remark = data.get("opmerking") or data.get("remark", "")
@@ -662,16 +706,16 @@ def api_send_order():
     created_time = now.strftime('%H:%M')
 
     # 总价 & 小费
-    data["total"] = data.get("totaal") or (data.get("summary") or {}).get("total")
-    data["fooi"] = float(data.get("tip") or 0)
-    data["bezorgkosten"] = data.get("delivery_cost") or (data.get("summary") or {}).get("delivery_cost") or 0
+    data["total"] = data.get("totaal")
+    data["fooi"] = tip
+    data["bezorgkosten"] = delivery_fee
     data["created_at"] = created_at
     data["status"] = "Pending"
 
     # 折扣处理
     discount_code = None
     discount_amount = None
-    order_total_val = float(data.get("totaal") or (data.get("summary") or {}).get("total") or 0)
+    order_total_val = float(data.get("totaal") or 0)
     if customer_email and order_total_val >= 20:
         discount_amount = round(order_total_val * 0.03, 2)
         discount_code = generate_discount_code()
@@ -1229,6 +1273,40 @@ def update_setting():
 def submit_order():
     data = request.get_json()
 
+    prices = load_prices()
+    items = data.get("items", {})
+    sanitized_items = {}
+    subtotal = 0.0
+    packaging_fee = 0.0
+    for name, item in items.items():
+        qty = int(item.get("qty", 0))
+        info = prices.get(name, {})
+        price = float(info.get("price", 0))
+        pack = float(info.get("packaging", 0))
+        subtotal += price * qty
+        packaging_fee += pack * qty
+        sanitized_items[name] = {"price": price, "qty": qty, "packaging": pack}
+    delivery_fee = 2.5 if data.get("orderType") == "bezorgen" else 0.0
+    tip = float(data.get("tip") or 0)
+    discount = float(data.get("discountAmount") or data.get("discount_amount") or 0)
+    btw = (subtotal + packaging_fee) * 9 / 109
+    totaal = subtotal + packaging_fee + delivery_fee + tip - discount
+    data["items"] = sanitized_items
+    data["subtotal"] = round(subtotal, 2)
+    data["packaging_fee"] = round(packaging_fee, 2)
+    data["delivery_fee"] = round(delivery_fee, 2)
+    data["btw"] = round(btw, 2)
+    data["totaal"] = round(totaal, 2)
+    data["total"] = data["totaal"]
+    data["summary"] = {
+        "subtotal": f"{subtotal:.2f}",
+        "packaging": f"{packaging_fee:.2f}",
+        "delivery": f"{delivery_fee:.2f}",
+        "discount_amount": f"{discount:.2f}",
+        "btw": f"{btw:.2f}",
+        "total": f"{totaal:.2f}",
+    }
+
     # ✅ 标准化 tijdslot 字段（处理 Z.S.M.）
     tijdslot = data.get("tijdslot") or data.get("pickup_time") or data.get("delivery_time")
     tijdslot_raw = str(tijdslot).lower().replace(".", "").strip()
@@ -1247,7 +1325,7 @@ def submit_order():
     created_at = now.strftime('%Y-%m-%d %H:%M:%S')
     created_date = now.strftime('%Y-%m-%d')
     created_time = now.strftime('%H:%M')
-    data["total"] = data.get("totaal") or (data.get("summary") or {}).get("total")
+    data["total"] = data.get("totaal")
     data["fooi"] = float(data.get("tip") or 0)
     data["created_at"] = created_at
     data["status"] = "Pending"
@@ -1273,7 +1351,7 @@ def submit_order():
     # ✅ 折扣处理
     discount_code = None
     discount_amount = None
-    order_total_val = float(data.get("totaal") or (data.get("summary") or {}).get("total") or 0)
+    order_total_val = float(data.get("totaal") or 0)
     if customer_email and order_total_val >= 20:
         discount_amount = round(order_total_val * 0.03, 2)
         discount_code = generate_discount_code()
@@ -1282,7 +1360,7 @@ def submit_order():
 
     # ✅ 在线支付处理（先记录订单）
     if payment_method == "online":
-        amount = float(data.get("totaal") or (data.get("summary") or {}).get("total") or 0)
+        amount = float(data.get("totaal") or 0)
         payment_link, payment_id = create_mollie_payment(
             data.get("order_number") or data.get("orderNumber"), amount
         )

--- a/prices.json
+++ b/prices.json
@@ -1,0 +1,326 @@
+{
+  "Japans Chicken Bento": {
+    "price": 22.0,
+    "packaging": 0.2
+  },
+  "Korean Chicken Bento": {
+    "price": 22.0,
+    "packaging": 0.2
+  },
+  "Korean Beef Bento": {
+    "price": 25.0,
+    "packaging": 0.2
+  },
+  "Meatlover Bento": {
+    "price": 25.0,
+    "packaging": 0.2
+  },
+  "Zalm Lover Bento": {
+    "price": 23.0,
+    "packaging": 0.2
+  },
+  "Ebi Lover Bento": {
+    "price": 23.0,
+    "packaging": 0.2
+  },
+  "Surf & Turf Bento": {
+    "price": 25.0,
+    "packaging": 0.2
+  },
+  "Dimsum Bento": {
+    "price": 20.0,
+    "packaging": 0.2
+  },
+  "Lamskotelet Bento": {
+    "price": 30.0,
+    "packaging": 0.2
+  },
+  "Unagi Bento": {
+    "price": 24.0,
+    "packaging": 0.2
+  },
+  "Tuna Bento": {
+    "price": 25.0,
+    "packaging": 0.2
+  },
+  "Veggie Bento": {
+    "price": 20.0,
+    "packaging": 0.2
+  },
+  "Bento Sushi Omakase": {
+    "price": 22.0,
+    "packaging": 0.2
+  },
+  "Xbento": {
+    "price": 25.0,
+    "packaging": 0.2
+  },
+  "Ebi Furai": {
+    "price": 18.0,
+    "packaging": 0.2
+  },
+  "Chicken": {
+    "price": 18.0,
+    "packaging": 0.2
+  },
+  "Beef": {
+    "price": 18.0,
+    "packaging": 0.2
+  },
+  "Ribeye": {
+    "price": 18.0,
+    "packaging": 0.2
+  },
+  "Chasiu": {
+    "price": 18.0,
+    "packaging": 0.2
+  },
+  "Zhai": {
+    "price": 18.0,
+    "packaging": 0.2
+  },
+  "Zalm Bowl": {
+    "price": 15.0,
+    "packaging": 0.2
+  },
+  "Tuna Bowl": {
+    "price": 15.0,
+    "packaging": 0.2
+  },
+  "Ebi Fry Bowl": {
+    "price": 15.5,
+    "packaging": 0.2
+  },
+  "Chicken Karaage Bowl": {
+    "price": 15.5,
+    "packaging": 0.2
+  },
+  "Spicy Chicken Bowl": {
+    "price": 15.5,
+    "packaging": 0.2
+  },
+  "Teriyaki Chicken Bowl": {
+    "price": 15.5,
+    "packaging": 0.2
+  },
+  "Teriyaki Beef Bowl": {
+    "price": 15.5,
+    "packaging": 0.2
+  },
+  "California Bowl": {
+    "price": 14.0,
+    "packaging": 0.2
+  },
+  "Unagi Bowl": {
+    "price": 16.0,
+    "packaging": 0.2
+  },
+  "Vega Bowl": {
+    "price": 13.0,
+    "packaging": 0.2
+  },
+  "Meatlover Bowl": {
+    "price": 17.0,
+    "packaging": 0.2
+  },
+  "Rainbow Bowl": {
+    "price": 17.0,
+    "packaging": 0.2
+  },
+  "Spicy Tuna Bowl": {
+    "price": 15.5,
+    "packaging": 0.2
+  },
+  "Flamed Zalm Bowl": {
+    "price": 16.0,
+    "packaging": 0.2
+  },
+  "Flamed Tuna Bowl": {
+    "price": 16.0,
+    "packaging": 0.2
+  },
+  "X-Bowl": {
+    "price": 0.0,
+    "packaging": 0.2
+  },
+  "Teppanyaki Shrimp": {
+    "price": 18.0,
+    "packaging": 0.2
+  },
+  "Teppanyaki Beef": {
+    "price": 18.0,
+    "packaging": 0.2
+  },
+  "Teppanyaki Chicken": {
+    "price": 18.0,
+    "packaging": 0.2
+  },
+  "Teppanyaki Char Siu": {
+    "price": 18.0,
+    "packaging": 0.2
+  },
+  "Salmon Roll Omakase": {
+    "price": 16.0,
+    "packaging": 0.2
+  },
+  "Dragon Roll Omakase": {
+    "price": 16.0,
+    "packaging": 0.2
+  },
+  "Beef Roll Omakase": {
+    "price": 16.0,
+    "packaging": 0.2
+  },
+  "Chicken Roll Omakase": {
+    "price": 16.0,
+    "packaging": 0.2
+  },
+  "Nigiri Box Omakase": {
+    "price": 10.0,
+    "packaging": 0.2
+  },
+  "Salmon sashimi": {
+    "price": 10.5,
+    "packaging": 0.2
+  },
+  "Flamed salmon sashimi": {
+    "price": 10.0,
+    "packaging": 0.2
+  },
+  "Tonijn sashimi": {
+    "price": 10.0,
+    "packaging": 0.2
+  },
+  "Beef sashimi": {
+    "price": 10.0,
+    "packaging": 0.2
+  },
+  "Zalm crispy rice sandwich": {
+    "price": 7.0,
+    "packaging": 0.2
+  },
+  "Spicytuna crispy rice sandwich": {
+    "price": 7.0,
+    "packaging": 0.2
+  },
+  "Ebi crispy rice sandwich": {
+    "price": 7.0,
+    "packaging": 0.2
+  },
+  "Beef crispy rice sandwich": {
+    "price": 7.5,
+    "packaging": 0.2
+  },
+  "California crispy rice sandwich": {
+    "price": 7.5,
+    "packaging": 0.2
+  },
+  "Chicken crispy rice sandwich": {
+    "price": 7.0,
+    "packaging": 0.2
+  },
+  "Karaage": {
+    "price": 6.5,
+    "packaging": 0.2
+  },
+  "Ebi Fry – 4 st": {
+    "price": 6.5,
+    "packaging": 0.2
+  },
+  "Ebi kroket": {
+    "price": 5.0,
+    "packaging": 0.2
+  },
+  "Spicy Crispy Chicken – 5 st": {
+    "price": 6.5,
+    "packaging": 0.2
+  },
+  "Japans Zalm Nugget": {
+    "price": 6.5,
+    "packaging": 0.2
+  },
+  "Mini Loempia – 6 st": {
+    "price": 3.5,
+    "packaging": 0.2
+  },
+  "Chicken Loempia – 2 st": {
+    "price": 5.0,
+    "packaging": 0.2
+  },
+  "Gyoza – 5 st": {
+    "price": 5.0,
+    "packaging": 0.2
+  },
+  "Inktvis Ringen – 5 st": {
+    "price": 5.0,
+    "packaging": 0.2
+  },
+  "Sesambal – 5 st": {
+    "price": 5.0,
+    "packaging": 0.2
+  },
+  "Yakitori – 4 st": {
+    "price": 6.0,
+    "packaging": 0.2
+  },
+  "Edamame": {
+    "price": 4.5,
+    "packaging": 0.2
+  },
+  "Kimchi Komkommer": {
+    "price": 4.5,
+    "packaging": 0.2
+  },
+  "Kimchi Kool": {
+    "price": 5.0,
+    "packaging": 0.2
+  },
+  "Zeewiersalade – 100g": {
+    "price": 5.0,
+    "packaging": 0.2
+  },
+  "Mochi Mango": {
+    "price": 4.0,
+    "packaging": 0.2
+  },
+  "Mochi Aardbei": {
+    "price": 4.0,
+    "packaging": 0.2
+  },
+  "Mochi Matcha": {
+    "price": 4.0,
+    "packaging": 0.2
+  },
+  "Mochi Pistachio": {
+    "price": 4.0,
+    "packaging": 0.2
+  },
+  "Cola": {
+    "price": 2.5,
+    "packaging": 0.15
+  },
+  "Cola Zero": {
+    "price": 2.5,
+    "packaging": 0.15
+  },
+  "Spa Blauw": {
+    "price": 2.5,
+    "packaging": 0.15
+  },
+  "Spa Rood": {
+    "price": 2.5,
+    "packaging": 0.15
+  },
+  "Red Bull": {
+    "price": 2.5,
+    "packaging": 0.15
+  },
+  "Heineken 330ml": {
+    "price": 3.0,
+    "packaging": 0.15
+  },
+  "Bubble Tea": {
+    "price": 5.0,
+    "packaging": 0.2
+  }
+}


### PR DESCRIPTION
## Summary
- extract menu pricing from the frontend into a new `prices.json` file
- load prices from `prices.json` in the API and recalculate order totals on the server

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_6890fc9d83d88333b3b1ce5cb7d9e149