### PR TITLE
Format monetary and phone fields for Excel export

### DIFF
--- a/templates/admin_orders.html
+++ b/templates/admin_orders.html
@@ -152,12 +152,12 @@
               <td>${order.created_at || ''}</td>
               <td>${isDelivery ? 'Bezorgen' : 'Afhalen'}</td>
               <td>${order.customer_name || ''}</td>
-              <td>${order.phone || ''}</td>
+              <td>${order.phone_excel || order.phone || ''}</td>
               <td>${order.email || '-'}</td>
               <td><ul>${items}</ul></td>
               <td>${order.opmerking || order.remark || '-'}</td>
-              <td>${formatCurrency(fooi)}</td>
-              <td>${formatCurrency(tot)}</td>
+              <td>${order.fooi_excel || formatCurrency(fooi)}</td>
+              <td>${order.totaal_excel || formatCurrency(tot)}</td>
               <td>${isDelivery ? `${order.street} ${order.house_number} ${order.postcode} ${order.city}${order.maps_link ? ` <a href="${order.maps_link}" target="_blank">📍Maps</a>` : ''}` : '-'}</td>
               <td>${isDelivery ? (order.delivery_time || order.deliveryTime || '-') : (order.pickup_time || order.pickupTime || '-')}</td>
               <td>${order.payment_method || ''}</td>

--- a/templates/orders_table.html
+++ b/templates/orders_table.html
@@ -105,7 +105,7 @@ th:last-child {
           </span>
         </td>
         <td>{{ order.customer_name or '' }}</td>
-        <td>{{ order.phone or '' }}</td>
+        <td>{{ order.phone_excel or order.phone or '' }}</td>
         <td>{{ order.email or '-' }}</td>
         <td>
           <ul>
@@ -117,7 +117,7 @@ th:last-child {
        <td>{{ order.opmerking or '-' }}</td>
        <td>€{{ '%.2f' % (order.fooi or order.tip or 0) }}</td>
 
-        <td>€{{ '%.2f' % (order.totaal or 0) }}</td>
+       <td>{{ order.totaal_excel or ('€' + ('%.2f' % (order.totaal or 0)).replace('.', ',')) }}</td>
 
         <td>
           {% if is_delivery %}

--- a/templates/pos_orders.html
+++ b/templates/pos_orders.html
@@ -73,7 +73,7 @@ th:last-child {
       <td><span class="{{ 'type-bezorging' if is_delivery else 'type-afhalen' }}">{{ 'Bezorging' if is_delivery else 'Afhalen' }}</span></td>
 
       <td>{{ order.customer_name or '' }}</td>
-      <td>{{ order.phone or '' }}</td>
+      <td>{{ order.phone_excel or order.phone or '' }}</td>
       <td>{{ order.email or '-' }}</td>
 
       <td>
@@ -87,7 +87,7 @@ th:last-child {
       <td>{{ order.opmerking or '-' }}</td>
 
       <!-- ✅ 只显示 één prijswaarde -->
-      <td>€{{ '%.2f' % (order.totaal or 0) }}</td>
+      <td>{{ order.totaal_excel or ('€' + ('%.2f' % (order.totaal or 0)).replace('.', ',')) }}</td>
 
       <td>
         {% if is_delivery %}
@@ -216,7 +216,7 @@ function insertSorted(tbody,tr){
 
   <td>${isDelivery ? 'Bezorgen' : 'Afhalen'}</td>
   <td>${order.customer_name || ''}</td>
-  <td>${order.phone || ''}</td>
+  <td>${order.phone_excel || order.phone || ''}</td>
   <td>${order.email || '-'}</td>
   <td><ul>${items}</ul></td>
   <td>${remark || '-'}</td>
@@ -249,7 +249,7 @@ function insertSorted(tbody,tr){
       lines.push('---');
       Object.entries(o.items||{}).forEach(([n,i])=>lines.push(`${i.qty} x ${n}`));
       lines.push('---');
-      lines.push(`Totaal: €${parseFloat(o.totaal).toFixed(2)}`);
+      lines.push(`Totaal: ${o.totaal_excel || formatCurrency(o.totaal)}`);
       const t=o.delivery_time||o.deliveryTime||o.pickup_time||o.pickupTime||o.tijdslot||'';
       if(t) lines.push(`Tijd: ${t}`);
       return lines.join('\n');


### PR DESCRIPTION
## Summary
- Add helpers to format currency and phone numbers into Excel-friendly representations
- Attach formatted `*_excel` fields for orders and items
- Use formatted values in admin and POS order templates

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68a21de100a88333ab2896aada91f4b6