### PR TITLE
feat: add statiegeld support

### DIFF
--- a/templates/admin_orders.html
+++ b/templates/admin_orders.html
@@ -51,6 +51,7 @@
           <th>Items</th>
           <th>Opmerking</th>
           <th>Fooi (€)</th>
+          <th>Statiegeld (€)</th>
           <th>Totaal (€)</th>
           <th>Adres</th>
           <th>Tijdslot</th>
@@ -129,10 +130,14 @@
           data.forEach(order => {
             const tr = document.createElement('tr');
             const isDelivery = ['delivery', 'bezorgen'].includes((order.order_type || '').toLowerCase());
-            const items = Object.entries(order.items || {}).map(([n, i]) => `<li>${n} x ${i.qty}</li>`).join('');
+          const items = Object.entries(order.items || {}).map(([n, i]) => `<li>${n} x ${i.qty}</li>`).join('');
             let fooi = parseFloat(order.fooi);
             if (isNaN(fooi)) {
               fooi = 0;
+            }
+            let statiegeld = parseFloat(order.statiegeld);
+            if (isNaN(statiegeld)) {
+              statiegeld = 0;
             }
             let tot = order.totaal ?? order.total ?? 0;
             if (typeof tot === 'string') {
@@ -157,6 +162,7 @@
               <td><ul>${items}</ul></td>
               <td>${order.opmerking || order.remark || '-'}</td>
               <td>${order.fooi_excel || formatCurrency(fooi)}</td>
+              <td>${order.statiegeld_excel || formatCurrency(statiegeld)}</td>
               <td>${order.totaal_excel || formatCurrency(tot)}</td>
               <td>${isDelivery ? `${order.street} ${order.house_number} ${order.postcode} ${order.city}${order.maps_link ? ` <a href="${order.maps_link}" target="_blank">📍Maps</a>` : ''}` : '-'}</td>
               <td>${isDelivery ? (order.delivery_time || order.deliveryTime || '-') : (order.pickup_time || order.pickupTime || '-')}</td>

--- a/templates/orders_table.html
+++ b/templates/orders_table.html
@@ -85,6 +85,7 @@ th:last-child {
        <th>Items</th>
        <th>Opmerking</th>
        <th>Fooi</th>
+       <th>Statiegeld</th>
        <th>Totaal</th>
        <th>Adres</th>
        <th>Tijdslot</th>
@@ -113,9 +114,10 @@ th:last-child {
             <li>{{ name }} x {{ item['qty'] }}</li>
           {% endfor %}
           </ul>
-        </td>
+       </td>
        <td>{{ order.opmerking or '-' }}</td>
        <td>€{{ '%.2f' % (order.fooi or order.tip or 0) }}</td>
+       <td>€{{ '%.2f' % (order.statiegeld or 0) }}</td>
 
        <td>{{ order.totaal_excel or ('€' + ('%.2f' % (order.totaal or 0)).replace('.', ',')) }}</td>
 

--- a/templates/pos.html
+++ b/templates/pos.html
@@ -2622,6 +2622,9 @@ function editOrder(btn) {
   const fooi = prompt('Fooi', data.fooi != null ? data.fooi : (data.tip || '0'));
   if (fooi === null) return;
 
+  const statiegeld = prompt('Statiegeld', data.statiegeld != null ? data.statiegeld : '0');
+  if (statiegeld === null) return;
+
   fetch(`/api/orders/${id}`, {
     method: 'PUT',
     headers: { 'Content-Type': 'application/json' },
@@ -2632,7 +2635,8 @@ function editOrder(btn) {
       items: parseItemsString(newItemsInput, data.items || {}),
       payment_method: payment,
       totaal: parseFloat(totaal) || 0,
-      fooi: parseFloat(fooi) || 0
+      fooi: parseFloat(fooi) || 0,
+      statiegeld: parseFloat(statiegeld) || 0
     })
   }).then(() => fetchOrders());
 }
@@ -2673,12 +2677,14 @@ function addRow(order, highlight = false) {
   const bezorgDisplay = bezorgkosten.toFixed(2).replace('.', ',');
   let fooi = parseFloat(order.fooi || order.tip || 0); if (isNaN(fooi)) fooi = 0;
   const fooiDisplay = fooi.toFixed(2).replace('.', ',');
+  let statiegeld = parseFloat(order.statiegeld || 0); if (isNaN(statiegeld)) statiegeld = 0;
+  const statiegeldDisplay = statiegeld.toFixed(2).replace('.', ',');
 
   let totaal = parseFloat(order.totaal || order.total || 0);
   if (isNaN(totaal)) totaal = 0;
   const totaalDisplay = totaal.toFixed(2).replace('.', ',');
 
-  const theoretischTotaal = subtotal + verpakkingskosten + bezorgkosten + fooi;
+  const theoretischTotaal = subtotal + verpakkingskosten + bezorgkosten + fooi + statiegeld;
   let korting = theoretischTotaal - totaal;
   const showKorting = korting >= 0.01;
   const kortingDisplay = korting.toFixed(2).replace('.', ',');
@@ -2725,6 +2731,7 @@ function addRow(order, highlight = false) {
     ${bezorgkosten > 0 ? `<div><strong>Bezorgkosten:</strong> €${bezorgDisplay}</div>` : ''}
     ${showKorting ? `<div><strong>Kassa Korting:</strong> -€${kortingDisplay}</div>` : ''}
     <div><strong>Totaal:</strong> €${totaalDisplay}</div>
+    ${statiegeld > 0 ? `<div><strong>Statiegeld:</strong> €${statiegeldDisplay}</div>` : ''}
     ${fooi > 0 ? `<div><strong>Fooi:</strong> €${fooiDisplay}</div>` : ''}
     ${address !== '-' ? `<div><strong>Adres:</strong> ${address}
       <a href="https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(address)}" target="_blank" style="margin-left:6px;">📍Maps</a>


### PR DESCRIPTION
## Summary
- support statiegeld amount throughout API and exports
- show statiegeld alongside fooi in POS and admin tables

## Testing
- `python -m py_compile app.py`
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a3ec82ae088333a6ee800653004d2c