### PR TITLE
Add statiegeld column and export support

### DIFF
--- a/templates/admin_orders.html
+++ b/templates/admin_orders.html
@@ -51,6 +51,7 @@
           <th>Items</th>
           <th>Opmerking</th>
           <th>Fooi (€)</th>
+          <th>Statiegeld (€)</th>
           <th>Totaal (€)</th>
           <th>Adres</th>
           <th>Tijdslot</th>
@@ -134,6 +135,10 @@
             if (isNaN(fooi)) {
               fooi = 0;
             }
+            let statiegeld = parseFloat(order.statiegeld);
+            if (isNaN(statiegeld)) {
+              statiegeld = 0;
+            }
             let tot = order.totaal ?? order.total ?? 0;
             if (typeof tot === 'string') {
               tot = parseFloat(tot.replace(/[^\d,.-]/g, '').replace(',', '.'));
@@ -157,6 +162,7 @@
               <td><ul>${items}</ul></td>
               <td>${order.opmerking || order.remark || '-'}</td>
               <td>${order.fooi_excel || formatCurrency(fooi)}</td>
+                <td>${order.statiegeld_excel || formatCurrency(statiegeld)}</td>
               <td>${order.totaal_excel || formatCurrency(tot)}</td>
               <td>${isDelivery ? `${order.street} ${order.house_number} ${order.postcode} ${order.city}${order.maps_link ? ` <a href="${order.maps_link}" target="_blank">📍Maps</a>` : ''}` : '-'}</td>
               <td>${isDelivery ? (order.delivery_time || order.deliveryTime || '-') : (order.pickup_time || order.pickupTime || '-')}</td>

--- a/templates/pos.html
+++ b/templates/pos.html
@@ -2673,12 +2673,14 @@ function addRow(order, highlight = false) {
   const bezorgDisplay = bezorgkosten.toFixed(2).replace('.', ',');
   let fooi = parseFloat(order.fooi || order.tip || 0); if (isNaN(fooi)) fooi = 0;
   const fooiDisplay = fooi.toFixed(2).replace('.', ',');
+  let statiegeld = parseFloat(order.statiegeld || 0); if (isNaN(statiegeld)) statiegeld = 0;
+  const statiegeldDisplay = statiegeld.toFixed(2).replace('.', ',');
 
   let totaal = parseFloat(order.totaal || order.total || 0);
   if (isNaN(totaal)) totaal = 0;
   const totaalDisplay = totaal.toFixed(2).replace('.', ',');
 
-  const theoretischTotaal = subtotal + verpakkingskosten + bezorgkosten + fooi;
+  const theoretischTotaal = subtotal + verpakkingskosten + bezorgkosten + fooi + statiegeld;
   let korting = theoretischTotaal - totaal;
   const showKorting = korting >= 0.01;
   const kortingDisplay = korting.toFixed(2).replace('.', ',');
@@ -2726,6 +2728,7 @@ function addRow(order, highlight = false) {
     ${showKorting ? `<div><strong>Kassa Korting:</strong> -€${kortingDisplay}</div>` : ''}
     <div><strong>Totaal:</strong> €${totaalDisplay}</div>
     ${fooi > 0 ? `<div><strong>Fooi:</strong> €${fooiDisplay}</div>` : ''}
+      ${statiegeld > 0 ? `<div><strong>Statiegeld:</strong> €${statiegeldDisplay}</div>` : ''}
     ${address !== '-' ? `<div><strong>Adres:</strong> ${address}
       <a href="https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(address)}" target="_blank" style="margin-left:6px;">📍Maps</a>
     </div>` : ''}


### PR DESCRIPTION
## Summary
- show statiegeld amounts across admin order overview and POS order details
- include statiegeld in order exports and calculations

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68a3ee5702008333b5d2d649e872d5a1